### PR TITLE
fix extrapolation bug

### DIFF
--- a/IMU_KalmanFilter.cpp
+++ b/IMU_KalmanFilter.cpp
@@ -77,7 +77,7 @@ void KalmanFilter::prediction(float Angle, float Rate)
         KF_Angle += dT * newRate;
 
         // 2. Extrapolate uncertainty
-        P[0][0] += (P[0][1] + P[1][1]) * dT + Q_Angle * dT;
+        P[0][0] += ((dT * P[1][1] - P[0][1] - P[1][0]) + Q_Angle) * dT;
         P[0][1] -= P[1][1] * dT;
         P[1][0] -= P[1][1] * dT;
         P[1][1] += Q_Bias * dT;


### PR DESCRIPTION
Fixed the error causing the filter estimated values ​​to be reset due to an incorrect formula in the extrapolation of uncertainty in the prediction step.